### PR TITLE
CPU: fix branch page crossing + offset calulation

### DIFF
--- a/src/cpu.jakt
+++ b/src/cpu.jakt
@@ -1426,10 +1426,10 @@ class CPU {
         .pc += 2
         
         let offset: u8 = 0
-        let negative = false
+        let negative_offset = false
         if (operand < 0) {
             offset = (operand * -1) as! u8
-            negative = true
+            negative_offset = true
         } else {
             offset = operand as! u8
         }
@@ -1437,7 +1437,7 @@ class CPU {
         let prev_page = .pc >> 8
         
         // TODO: please add a test for this
-        if (negative) {
+        if (negative_offset) {
             .pc = .pc - (offset as! u16)
         } else {
             .pc = .pc + (offset as! u16)

--- a/src/cpu.jakt
+++ b/src/cpu.jakt
@@ -1429,6 +1429,7 @@ class CPU {
         let negative = false
         if (operand < 0) {
             offset = (operand * -1) as! u8
+            negative = true
         } else {
             offset = operand as! u8
         }

--- a/src/cpu.jakt
+++ b/src/cpu.jakt
@@ -1425,10 +1425,10 @@ class CPU {
         // based upon that. Lets emulate that which also makes the code look cleaner
         .pc += 2
         
-        let offset: u8 = 0
-        let negative_offset = false
+        mut offset: u8 = 0
+        mut negative_offset = false
         if (operand < 0) {
-            offset = (operand * -1) as! u8
+            offset = (operand * -1i8) as! u8
             negative_offset = true
         } else {
             offset = operand as! u8

--- a/src/cpu.jakt
+++ b/src/cpu.jakt
@@ -1419,13 +1419,29 @@ class CPU {
 
     function branch(mut this) {
         let arg_address = .pc + 1
-        let address: i8 = .system.read_byte(address: arg_address) as! i8
-
+        let operand: i8 = .system.read_byte(address: arg_address) as! i8
+        
+        // The 6502 would have the PC on the next opcode now and everything is
+        // based upon that. Lets emulate that which also makes the code look cleaner
+        .pc += 2
+        
+        let offset: u8 = 0
+        let negative = false
+        if (operand < 0) {
+            offset = (operand * -1) as! u8
+        } else {
+            offset = operand as! u8
+        }
+        
         let prev_page = .pc >> 8
-
+        
         // TODO: please add a test for this
-        .pc = (.pc as! i16 + address as! i16) as! u16
-
+        if (negative) {
+            .pc = .pc - (offset as! u16)
+        } else {
+            .pc = .pc + (offset as! u16)
+        }
+        
         let new_page = .pc >> 8
 
         if prev_page != new_page {


### PR DESCRIPTION
Page crossing and offset during a branch are computed from the next instruction onward, because the 6502 advances the PC during fetching of the opcode and operand

This means, that a branch at CFFE to D0xx doesnt count as crossing a page boundary. Advancement of the PC also causes the base address of the branch to shift, as the offset is not applied to where the branch opcode is, but where the PC is after reading the whole branch instruction.

I also changed how the PC is set to avoid casting the PC to i16 and back to u16, just to get rid of a potential headache with the high bit of the PC being set and potentially causing the i16 representation to be negative (depending on how jakt/c++ do the cast in the background). 

~~Since I didnt have jakt around when writing these changes, I'll mark the PR as a draft for now.~~
Real PR now since I had a chance to pass it through jakt and fix all the compiler errors.