### PR TITLE
Fix invalid address in JSR

### DIFF
--- a/src/cpu.jakt
+++ b/src/cpu.jakt
@@ -1542,7 +1542,8 @@ class CPU {
     }
 
     function jsr(mut this) {
-        .push_word(value: .pc + 2)
+        // .pc is at the current opcode, so next pc is + 3
+        .push_word(value: .pc + 3)
 
         .clock += 6
 


### PR DESCRIPTION
We need to increase .pc with one because the pc is currently at the opcode.

Found when testing with nestest.nes