### PR TITLE
meta: Add CMake build, document Windows build steps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(
+    jaktnesmonster
+    DESCRIPTION "NES Emulator written in Jakt"
+    HOMEPAGE_URL "https://github.com/jntrnr/jaktnesmonster"
+    LANGUAGES CXX)
+
+find_package(Jakt REQUIRED)
+find_package(SDL2 REQUIRED)
+
+add_jakt_executable(jakt_nes
+    MAIN_SOURCE src/main.jakt
+    MODULE_SOURCES
+        src/apu.jakt
+        src/cart.jakt
+        src/cpu.jakt
+        src/ppu.jakt
+        src/sdl.jakt
+        src/system.jakt
+        src/video.jakt
+)
+
+target_compile_definitions(jakt_nes PRIVATE SDL_MAIN_HANDLED)
+target_link_libraries(jakt_nes PRIVATE SDL2::SDL2)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ Creating a NES emulator in the [jakt](https://github.com/SerenityOS/jakt) progra
 
 Make sure you have libsdl2+SDL2 headers installed, and build and install the jakt compiler into your PATH.
 
-Then, you can build using (Linux):
+## Building using jakt directly
+
+With jakt in your path and the install location of SDL2 known, you can build like so for Linux:
 
 ```
 > jakt src/main.jakt -l SDL2 -I <path to Jakt runtime directory> -O -o jakt_nes
@@ -14,4 +16,84 @@ On macOS, you can use (be sure to update versions to match your SDL2 version):
 
 ```
 > jakt src/main.jakt -l SDL2 -I /opt/homebrew/Cellar/sdl2/2.0.22/include -L /opt/homebrew/Cellar/sdl2/2.0.22/lib -I ../jakt/runtime -O -o jakt_nes
+```
+
+For Windows, keep reading into the CMake steps :^).
+
+## Building using CMake
+
+Instead of installing jakt into somewhere that's in your path, make sure to install jakt via the CMake build by setting CMAKE_INSTALL_PREFIX somewhere interesting, or passing --prefix on the command line . One decent option for prefix is "jakt-install".
+
+```
+jakt> cmake -B build -GNinja -DCMAKE_INSTALL_PREFIX=jakt-install -DCMAKE_CXX_COMPILER=clang++
+jakt> cmake --build build
+jakt> cmake --install build
+# alternative to setting CMAKE_INSTALL_PREFIX
+jakt> cmake --install build --prefix jakt-test
+```
+
+After that, you can build jaktnesmonster by passing the location of jakt CMake files to CMake. CMake should find SDL2 automatically, if it's in a standard install location for your platform (Linux, macOS, other Unix).
+
+```
+> cmake -G Ninja -B build -DCMAKE_PREFIX_PATH=../jakt/jakt-install -DCMAKE_CXX_COMPILER=clang++
+> cmake --build build
+# Alternatively
+> ninja -C build
+```
+
+### Building on Windows
+
+The easiest way to hook up SDL2 to CMake on windows is via [vcpkg](https://vcpkg.io/en/getting-started.html)
+
+Ensure that you have the VS 2019 or 2022 toolset installed, including clang. MSVC is not supported.
+
+Perform the above jakt install steps from a VS Developer Powershell instance.
+
+Next, install SDL2 via vcpkg from a VS Developer PowerShell instance:
+
+```powershell
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+.\bootstrap-vcpkg.bat
+.\vcpkg install sdl2:x64-windows
+```
+
+Finally, configure jaktnesmonster with CMake, passing your Windows install of jakt, the vcpkg toolchain file, and clang++ as the C++ compiler:
+
+```powershell
+cmake -B build -GNinja `
+    -DCMAKE_PREFIX_PATH="..\jakt\jakt-install\share" `
+    -DCMAKE_TOOLCHAIN_FILE="..\vcpkg\scripts\buildsystems\vcpkg.cmake" `
+    -DCMAKE_CXX_COMPILER=clang++
+```
+
+Now you can build jakt_nes.exe via
+
+```
+> cmake --build build
+```
+or
+```
+> ninja -C build
+```
+
+Alternatively, using Visual Studio directly to build, you can create a CMakeSettings.json similar to:
+
+```json
+{
+  "configurations": [
+    {
+      "name": "x64-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "inheritEnvironments": [ "clang_cl_x64_x64" ],
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "-DCMAKE_PREFIX_PATH=\"..\\jakt\\jakt-install\\share\" ",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "cmakeToolchain": "..\\vcpkg\\scripts\\buildsystems\\vcpkg.cmake"
+    }
+  ]
+}
 ```

--- a/src/sdl.jakt
+++ b/src/sdl.jakt
@@ -23,7 +23,8 @@ class SDL {
     public function init_video(mut this, width: i64, height: i64) {
         unsafe {
             cpp {
-                "SDL_Init(SDL_INIT_VIDEO);
+                "SDL_SetMainReady();
+                SDL_Init(SDL_INIT_VIDEO);
                 SDL_CreateWindowAndRenderer(width, height, 0, (SDL_Window **)&this->window, (SDL_Renderer **)&this->renderer);"
             }
         }

--- a/src/system.jakt
+++ b/src/system.jakt
@@ -41,7 +41,6 @@ class System {
         } else {
             return .mapper_read_byte(address)
         }
-        return 0
     }
 
     public function read_word(this, address: u16) -> u16 {


### PR DESCRIPTION
And fix some compile errors on latest jakt main while we're at it :^)

Make sure to do the proper main dance for SDL2 when compiling on
Windows, it does some weird stuff with main like #define main sdl_main.

I'll look into some Windows CI later, but I figured you'd want to try this out first. I'm "assuming" that Ali's action will work properly first try for windows... right? :)