### PR TITLE
ci: Use CMake build in CI for Linux, macOS and Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,44 @@ jobs:
   build:
     strategy:
       fail-fast: true
-    runs-on: ubuntu-latest
+      matrix:
+        os: [ubuntu-22.04, macos-latest, windows-latest]
+
+    runs-on: ${{ matrix.os }}
 
     steps:
+      - run: git config --global core.autocrlf false
+        if: ${{ matrix.os == 'windows-latest' }}
       - uses: actions/checkout@v3
-      - name: install_dependencies
+
+      - name: Install Dependencies Ubuntu
         run: |
           sudo apt-get update -y -qq
           sudo apt-get install libsdl2-dev
+        if : ${{ matrix.os == 'ubuntu-22.04' }}
+
+      - name: Install Dependencies macOS
+        run: |
+          brew install SDL2
+        if: ${{ matrix.os == 'macos-latest' }}
+
+      - name: Install Dependencies Windows
+        shell: bash
+        run: |
+          ${VCPKG_INSTALLATION_ROOT}/vcpkg install sdl2:x64-windows
+        if: ${{ matrix.os == 'windows-latest' }}
+
       - uses: SerenityOS/setup-jakt@v1
-      - run: mkdir build
-      - run: jakt src/main.jakt -l SDL2 -I /usr/include/SDL2 -R $JAKT_RUNTIME -O -o jakt_nes
+
+      - name: Configure CMake Unix
+        run: |
+          cmake -GNinja -B build -DCMAKE_CXX_COMPILER=clang++
+        if: ${{ matrix.os != 'windows-latest' }}
+
+      - name: Configure CMake Windows
+        shell: bash
+        run: |
+          cmake -GNinja -B build -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_TOOLCHAIN_FILE="${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake"
+        if: ${{ matrix.os == 'windows-latest' }}
+
+      - run: cmake --build build

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+build/
+CMakeSettings.json
+jakt_nes
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,8 @@ project(
     HOMEPAGE_URL "https://github.com/jntrnr/jaktnesmonster"
     LANGUAGES CXX)
 
-find_package(Jakt REQUIRED)
-find_package(SDL2 REQUIRED)
+find_package(Jakt CONFIG REQUIRED)
+find_package(SDL2 CONFIG REQUIRED)
 
 add_jakt_executable(jakt_nes
     MAIN_SOURCE src/main.jakt

--- a/src/sdl.jakt
+++ b/src/sdl.jakt
@@ -1,4 +1,4 @@
-import extern c "SDL2/SDL.h" {}
+import extern c "SDL.h" {}
 
 enum Key {
     Up


### PR DESCRIPTION
Gets SDL2 from apt for Ubuntu, homebrew for macOS and vcpkg for Windows.

Due to some unfortunate cmake mishaps with SDL2 < 2.0.16, we need to bump to Ubuntu 22.04 -- 20.04 (latest) has 2.0.10  instead.

Should consider enabling the caching on the jakt action for rapid fire commits, otherwise doing that action from 0 every time turns  about a ~6 minute build into a ~13 minute build.

Note that CMAKE_PREFIX_PATH comes in as an environment variable from the setup-jakt action thanks to me begging CxByte to add it.