### PR TITLE
Fix runtime assertion on branching with negative offsets

### DIFF
--- a/src/cpu.jakt
+++ b/src/cpu.jakt
@@ -1,5 +1,14 @@
 import system { System }
 
+// Sign extend byte
+function sxb(value: u8) -> u16 {
+    mut value_16 = value as! u16;
+    if (value > 0x7f) {
+        value_16 |= 0xff00
+    }
+    return value_16
+}
+
 class CPU {
     a: u8
     x: u8
@@ -1402,30 +1411,14 @@ class CPU {
 
     function branch(mut this) {
         let arg_address = .pc + 1
-        let operand: i8 = .system.read_byte(address: arg_address) as! i8
-        
+        let offset = .system.read_byte(address: arg_address)
+
         // The 6502 would have the PC on the next opcode now and everything is
         // based upon that. Lets emulate that which also makes the code look cleaner
         .pc += 2
-        
-        mut offset: u8 = 0
-        mut negative_offset = false
-        if (operand < 0) {
-            offset = (operand * -1i8) as! u8
-            negative_offset = true
-        } else {
-            offset = operand as! u8
-        }
-        
+
         let prev_page = .pc >> 8
-        
-        // TODO: please add a test for this
-        if (negative_offset) {
-            .pc = .pc - (offset as! u16)
-        } else {
-            .pc = .pc + (offset as! u16)
-        }
-        
+        .pc = unchecked_add(.pc, sxb(value: offset))
         let new_page = .pc >> 8
 
         if prev_page != new_page {


### PR DESCRIPTION
The jakt runtime will error when trying to cast an operand > 0x7f using
`as! i8`. Replace the `i8` types with sign-extended `u8` to `u16` and
wrapping addition with `unchecked_add`.
