### PR TITLE
CPU improvements and fixes

### DIFF
--- a/src/cpu.jakt
+++ b/src/cpu.jakt
@@ -1459,7 +1459,7 @@ class CPU {
 
     function push_word(mut this, value: u16) {       
 
-        let first_byte = (value && 0xff00) as! u8
+        let first_byte = (value >> 8) as! u8
         .push_byte(value: first_byte)
 
         let second_byte = (value & 0x00ff) as! u8
@@ -1542,7 +1542,6 @@ class CPU {
         }
 
         .push_byte(value: intermediate)
-        .s -= 1
     }
 
     function php(mut this) {

--- a/src/cpu.jakt
+++ b/src/cpu.jakt
@@ -286,9 +286,7 @@ class CPU {
         let pre_index = .system.read_word(address)
         let page = pre_index >> 8
 
-        //let new_address: u16 = ((pre_index as! u32 + .y as! u32) && 0xffff)
         let new_address: u16 = unchecked_add<u16>(pre_index, .y as! u16)   
-
         let new_page = new_address >> 8
 
         // Example of crossing pages:
@@ -325,7 +323,6 @@ class CPU {
     function absolute_x(mut this, check_extra_clock: bool) -> u8 {
         let arg_address = .pc + 1
         mut address = .system.read_word(address: arg_address)
-
         let page = address >> 8
 
         address = unchecked_add<u16>(.x as! u16, address)
@@ -342,11 +339,9 @@ class CPU {
 
     function absolute_x_set(mut this, value: u8) {
         let arg_address = .pc + 1
-        mut address = .system.read_word(address: arg_address)
+        let address = .system.read_word(address: arg_address)
 
-        address = unchecked_add<u16>(.x as! u16, address)
-
-        .system.write_byte(address, value)
+        .system.write_byte(unchecked_add<u16>(.x as! u16, address), value)
     }
 
     function absolute_y(mut this, check_extra_clock: bool) -> u8 {
@@ -368,11 +363,9 @@ class CPU {
     
     function absolute_y_set(mut this, value: u8) {
         let arg_address = .pc + 1
-        mut address = .system.read_word(address: arg_address)
+        let address = .system.read_word(address: arg_address)
 
-        address = unchecked_add<u16>(.y as! u16, address)
-
-        .system.write_byte(address, value)
+        .system.write_byte(unchecked_add<u16>(.y as! u16, address), value)
     }
 
     function test_nz_flags(mut this, value: u8) {
@@ -1684,32 +1677,27 @@ class CPU {
     function rts(mut this) {
         .clock += 6
         .pc = .pull_word() + 1
-        eprintln("RTS, continuing at {:0>4x}", .pc)
     }
 
     function jmp(mut this, opcode: u8) {
         let low_byte_arg = .system.read_byte(address: .pc + 1)
         let high_byte_arg = .system.read_byte(address: .pc + 2) as! u16
         let arg = (high_byte_arg << 8) + low_byte_arg as! u16
-        eprintln("JMP, arg is {:0>4x}", arg)
         // let arg_address = .pc + 1
         
-        
-
         match opcode {
             0x4c => {
                 let address = arg
-                eprintln("Absolute JMP, new PC is {:0>4x}", address)
                 .clock += 3
                 .pc = address
             }
             0x6c => {
+                // Indirect jumps wrap the current page if read starts on the last byte of the page
                 let low_byte = .system.read_byte(address: arg)
                 let high_byte_address = (high_byte_arg << 8) + unchecked_add<u8>(low_byte_arg, 1u8) as! u16
                 let high_byte = .system.read_byte(address: high_byte_address)
                 .clock += 5
                 .pc = (high_byte as! u16 << 8) + low_byte as! u16
-                eprintln("Indirect JMP, new PC is {:0>4x}", .pc)
             }
             else => {
                 eprintln("unknown opcode")

--- a/src/cpu.jakt
+++ b/src/cpu.jakt
@@ -1641,13 +1641,17 @@ class CPU {
     }
 
     function brk(mut this) -> void {
-        .push_word(value: .pc)
+        // BRK increments pc, then pushes the pc,
+        // so our total PC offset to be pushed is 2.
+        // The break flag is also supposed to be set during the PC push 
+        .break_flag = true
+        .push_word(value: .pc + 2)
+        .push_status()
 
         .clock += 7
-
-        .pc = .system.read_word(address: 0xfffe)
-        .break_flag = true
         .interrupt_disable = true
+        
+        .pc = .system.read_word(address: 0xfffe)
     }
 
     function rti(mut this) {

--- a/src/cpu.jakt
+++ b/src/cpu.jakt
@@ -1653,8 +1653,8 @@ class CPU {
     }
 
     function jsr(mut this) {
-        // .pc is at the current opcode, so next pc is + 3
-        .push_word(value: .pc + 3)
+        // We push the address just before the next opcode, which is pc + 2
+        .push_word(value: .pc + 2)
 
         .clock += 6
 
@@ -1665,6 +1665,7 @@ class CPU {
     function rts(mut this) {
         .clock += 6
         .pull_pc()
+        .pc += 1
     }
 
     function jmp(mut this, opcode: u8) {

--- a/src/cpu.jakt
+++ b/src/cpu.jakt
@@ -241,25 +241,25 @@ class CPU {
 
     function zero_page_x(mut this) -> u8 {
         let arg_address = .pc + 1
-        let address = (.system.read_byte(address: arg_address) + .x) as! u16
+        let address = unchecked_add<u8>(.system.read_byte(address: arg_address), .x) as! u16
         return .system.read_byte(address)
     }
 
     function zero_page_x_set(mut this, value: u8) {
         let arg_address = .pc + 1
-        let address = (.system.read_byte(address: arg_address) + .x) as! u16
+        let address = unchecked_add<u8>(.system.read_byte(address: arg_address), .x) as! u16
         .system.write_byte(address, value)
     }
 
     function zero_page_y(mut this) -> u8 {
         let arg_address = .pc + 1
-        let address = (.system.read_byte(address: arg_address) + .y) as! u16
+        let address = unchecked_add<u8>(.system.read_byte(address: arg_address), .y) as! u16
         return .system.read_byte(address)        
     }
 
     function indirect_zero_page_x(mut this) -> u8 {
         let arg_address = .pc + 1
-        let address = (.system.read_byte(address: arg_address) + .x) as! u16
+        let address = unchecked_add<u8>(.system.read_byte(address: arg_address), .x) as! u16
         let new_address = .system.read_word(address)
 
         return .system.read_byte(address: new_address)
@@ -271,11 +271,9 @@ class CPU {
 
         let pre_index = .system.read_word(address)
         let page = pre_index >> 8
-        
-        
-        
-        let new_address: u16 = ((pre_index as! u32 + .y as! u32) && 0xffff)
-       
+
+        //let new_address: u16 = ((pre_index as! u32 + .y as! u32) && 0xffff)
+        let new_address: u16 = unchecked_add<u16>(pre_index, .y as! u16)   
 
         let new_page = new_address >> 8
 
@@ -306,7 +304,7 @@ class CPU {
 
         let page = address >> 8
 
-        address += .x as! u16
+        address = unchecked_add<u16>(.x as! u16, address)
         let new_page = address >> 8
 
         // Example of crossing pages:
@@ -322,7 +320,7 @@ class CPU {
         let arg_address = .pc + 1
         mut address = .system.read_word(address: arg_address)
 
-        address += .x as! u16
+        address = unchecked_add<u16>(.x as! u16, address)
 
         .system.write_byte(address, value)
     }

--- a/src/cpu.jakt
+++ b/src/cpu.jakt
@@ -1470,10 +1470,7 @@ class CPU {
     }
     
     function pull_word(mut this) -> u16 {
-        .s += 1
-        let value = .system.read_word(address: 0x100u16 + .s as! u16)
-        .s += 1
-        return value
+        return .pull_byte() + (.pull_byte() << 8)
     }
 
     function pla(mut this) {

--- a/src/cpu.jakt
+++ b/src/cpu.jakt
@@ -1448,13 +1448,38 @@ class CPU {
 
         .s = .x
     }
+    
+    function push_byte(mut this, value: u8) {
+        .system.write_byte(address: (0x100u16 + .s as! u16), value)
+        .s -= 1
+    }
+
+    function push_word(mut this, value: u16) {       
+
+        let first_byte = (value && 0xff00) as! u8
+        .push_byte(value: first_byte)
+
+        let second_byte = (value & 0x00ff) as! u8
+        .push_byte(value: second_byte)
+    }
+    
+    function pull_byte(mut this) -> u8 {
+        .s += 1
+        return .system.read_byte(address: (0x100u16 + .s as! u16))
+    }
+    
+    function pull_word(mut this) -> u16 {
+        .s += 1
+        let value = .system.read_word(address: 0x100u16 + .s as! u16)
+        .s += 1
+        return value
+    }
 
     function pla(mut this) {
         .pc += 1
         .clock += 4
 
-        .s += 1
-        let intermediate = .system.read_byte(address: 0x100u16 + .s as! u16)
+        let intermediate = .pull_byte()
 
         // set the flags
         .test_nz_flags(value: intermediate)
@@ -1465,13 +1490,11 @@ class CPU {
         .pc += 1
         .clock += 3
 
-        .system.write_byte(address: 0x100u16 + .s as! u16, value: .a)
-        .s -= 1
+        .push_byte(value: .a)
     }
 
     function pull_status(mut this) {
-        .s += 1
-        let intermediate = .system.read_byte(address: 0x100u16 + .s as! u16)
+        let intermediate = .pull_byte()
 
         .negative = ((intermediate & 0x80) == 0x80)
         .overflow = ((intermediate & 0x40) == 0x40)
@@ -1479,12 +1502,6 @@ class CPU {
         .interrupt_disable = ((intermediate & 0x04) == 0x04)
         .zero = ((intermediate & 0x02) == 0x02)
         .carry = ((intermediate & 0x01) == 0x01)
-    }
-
-    function pull_pc(mut this) {
-        .s += 1
-        .pc = .system.read_word(address: 0x100u16 + .s as! u16)
-        .s += 1
     }
 
     function plp(mut this) {
@@ -1521,19 +1538,7 @@ class CPU {
             intermediate |= 0x1
         }
 
-        .system.write_byte(address: 0x100u16 + .s as! u16, value: intermediate)
-        .s -= 1
-    }
-
-    function push_word(mut this, value: u16) {
-        // TODO: What order do we push our bytes?
-
-        let first_byte = (value >> 8) as! u8
-        .system.write_byte(address: (0x100u16 + .s as! u16), value: first_byte)
-        .s -= 1
-
-        let second_byte = (value & 0xff) as! u8
-        .system.write_byte(address: (0x100u16 + .s as! u16), value: second_byte)
+        .push_byte(value: intermediate)
         .s -= 1
     }
 
@@ -1649,7 +1654,7 @@ class CPU {
         .clock += 6
 
         .pull_status()
-        .pull_pc()
+        .pc = .pull_word()
     }
 
     function jsr(mut this) {
@@ -1664,8 +1669,7 @@ class CPU {
 
     function rts(mut this) {
         .clock += 6
-        .pull_pc()
-        .pc += 1
+        .pc = .pull_word() + 1
     }
 
     function jmp(mut this, opcode: u8) {

--- a/src/cpu.jakt
+++ b/src/cpu.jakt
@@ -1470,7 +1470,10 @@ class CPU {
     }
     
     function pull_word(mut this) -> u16 {
-        return .pull_byte() + (.pull_byte() << 8)
+        mut value: u16 = .pull_byte() as! u16
+        value += (.pull_byte() as! u16) << 8
+        return value
+        
     }
 
     function pla(mut this) {
@@ -1671,22 +1674,32 @@ class CPU {
     function rts(mut this) {
         .clock += 6
         .pc = .pull_word() + 1
+        eprintln("RTS, continuing at {:0>4x}", .pc)
     }
 
     function jmp(mut this, opcode: u8) {
-        let arg_address = .pc + 1
+        let low_byte_arg = .system.read_byte(address: .pc + 1)
+        let high_byte_arg = .system.read_byte(address: .pc + 2) as! u16
+        let arg = (high_byte_arg << 8) + low_byte_arg as! u16
+        eprintln("JMP, arg is {:0>4x}", arg)
+        // let arg_address = .pc + 1
+        
+        
 
         match opcode {
             0x4c => {
-                let address = .system.read_word(address: arg_address)
+                let address = arg
+                eprintln("Absolute JMP, new PC is {:0>4x}", address)
                 .clock += 3
                 .pc = address
             }
             0x6c => {
-                let indirect_address = .system.read_word(address: arg_address)
-                let address = .system.read_word(address: indirect_address)
+                let low_byte = .system.read_byte(address: arg)
+                let high_byte_address = (high_byte_arg << 8) + unchecked_add<u8>(low_byte_arg, 1u8) as! u16
+                let high_byte = .system.read_byte(address: high_byte_address)
                 .clock += 5
-                .pc = address
+                .pc = (high_byte as! u16 << 8) + low_byte as! u16
+                eprintln("Indirect JMP, new PC is {:0>4x}", .pc)
             }
             else => {
                 eprintln("unknown opcode")

--- a/src/cpu.jakt
+++ b/src/cpu.jakt
@@ -260,7 +260,7 @@ class CPU {
     function zero_page_y_set(mut this, value: u8) {
         let arg_address = .pc + 1
         let address = unchecked_add<u8>(.system.read_byte(address: arg_address), .y) as! u16
-        .system.write_byte(address)        
+        .system.write_byte(address, value)        
     }
 
     function indirect_zero_page_x(mut this) -> u8 {
@@ -341,7 +341,7 @@ class CPU {
         let arg_address = .pc + 1
         let address = .system.read_word(address: arg_address)
 
-        .system.write_byte(unchecked_add<u16>(.x as! u16, address), value)
+        .system.write_byte(address: unchecked_add<u16>(.x as! u16, address), value)
     }
 
     function absolute_y(mut this, check_extra_clock: bool) -> u8 {
@@ -365,7 +365,7 @@ class CPU {
         let arg_address = .pc + 1
         let address = .system.read_word(address: arg_address)
 
-        .system.write_byte(unchecked_add<u16>(.y as! u16, address), value)
+        .system.write_byte(address: unchecked_add<u16>(.y as! u16, address), value)
     }
 
     function test_nz_flags(mut this, value: u8) {
@@ -1459,7 +1459,6 @@ class CPU {
     }
 
     function push_word(mut this, value: u16) {       
-
         let first_byte = (value >> 8) as! u8
         .push_byte(value: first_byte)
 

--- a/src/cpu.jakt
+++ b/src/cpu.jakt
@@ -256,6 +256,12 @@ class CPU {
         let address = unchecked_add<u8>(.system.read_byte(address: arg_address), .y) as! u16
         return .system.read_byte(address)        
     }
+    
+    function zero_page_y_set(mut this, value: u8) {
+        let arg_address = .pc + 1
+        let address = unchecked_add<u8>(.system.read_byte(address: arg_address), .y) as! u16
+        .system.write_byte(address)        
+    }
 
     function indirect_zero_page_x(mut this) -> u8 {
         let arg_address = .pc + 1
@@ -263,6 +269,14 @@ class CPU {
         let new_address = .system.read_word(address)
 
         return .system.read_byte(address: new_address)
+    }
+    
+    function indirect_zero_page_x_set(mut this, value: u8) {
+        let arg_address = .pc + 1
+        let address = unchecked_add<u8>(.system.read_byte(address: arg_address), .x) as! u16
+        let new_address = .system.read_word(address)
+
+        .system.write_byte(address: new_address, value)
     }
 
     function indirect_zero_page_y(mut this, check_extra_clock: bool) -> u8 {
@@ -284,6 +298,16 @@ class CPU {
         }
 
         return .system.read_byte(address: new_address)
+    }
+    
+    function indirect_zero_page_y_set(mut this, value: u8) {
+        let arg_address = .pc + 1
+        let address = (.system.read_byte(address: arg_address)) as! u16
+
+        let pre_index = .system.read_word(address)
+        let new_address: u16 = unchecked_add<u16>(pre_index, .y as! u16)
+
+        .system.write_byte(address: new_address, value)
     }
 
     function absolute(mut this) -> u8 {
@@ -340,6 +364,15 @@ class CPU {
         }
 
         return .system.read_byte(address)
+    }
+    
+    function absolute_y_set(mut this, value: u8) {
+        let arg_address = .pc + 1
+        mut address = .system.read_word(address: arg_address)
+
+        address = unchecked_add<u16>(.y as! u16, address)
+
+        .system.write_byte(address, value)
     }
 
     function test_nz_flags(mut this, value: u8) {
@@ -1259,63 +1292,49 @@ class CPU {
                 // Zero page
                 .clock += 3
                 .pc += 2
-
-                let address = .system.read_byte(address: arg_address)
-                .system.write_byte(address: address as! u16, value: .a)
+                
+                .zero_page_set(value: .a)
             }
             0x95 => {
                 // Zero page, x
                 .clock += 4
                 .pc += 2
 
-                let address = .system.read_byte(address: arg_address)
-                // TODO: does this wrap around the zero page?
-                .system.write_byte(address: unchecked_add<u8>(address, .x) as! u16, value: .a)
+                .zero_page_x_set(value: .a)
             }
             0x8d => {
                 // Absolute
                 .clock += 4
                 .pc += 3
 
-                let address = .system.read_word(address: arg_address)
-                .system.write_byte(address, value: .a)
+                .absolute_set(value: .a)
             }
             0x9d => {
                 // Absolute, X
                 .clock += 5
                 .pc += 3
 
-                let address = .system.read_word(address: arg_address)
-                .system.write_byte(address: unchecked_add<u16>(address, .x as! u16), value: .a)
+                .absolute_x_set(value: .a)
             }
             0x99 => {
                 // Absolute, Y
                 .clock += 5
                 .pc += 3
 
-                let address = .system.read_word(address: arg_address)
-                .system.write_byte(address: unchecked_add<u16>(address, .y as! u16), value: .a)
+                .absolute_y_set(value: .a)
             }
             0x81 => {
                 // Indirect, X
                 .clock += 6
                 .pc += 2
 
-                let address = (.system.read_byte(address: arg_address) + .x) as! u16
-                .system.write_byte(address, value: .a)
+                .indirect_zero_page_x_set(value: .a)
             }
             0x91 => {
                 // Indirect, Y
                 .clock += 6
                 .pc += 2
-
-                let address = (.system.read_byte(address: arg_address)) as! u16
-
-                let pre_index = .system.read_word(address)
-
-                let new_address = pre_index + .y as! u16
-
-                .system.write_byte(address: new_address, value: .a)
+                .indirect_zero_page_y_set(value: .a)
             }
             else => {
                 eprintln("unknown opcode")
@@ -1332,25 +1351,20 @@ class CPU {
                 .clock += 3
                 .pc += 2
 
-                let address = .system.read_byte(address: arg_address)
-                .system.write_byte(address: address as! u16, value: .x)
+                .zero_page_set(value: .x)
             }
             0x96 => {
                 // Zero page, Y
                 .clock += 4
                 .pc += 2
 
-                let address = .system.read_byte(address: arg_address)
-                // TODO: does this wrap around the zero page?
-                .system.write_byte(address: unchecked_add<u8>(address, .y) as! u16, value: .x)
+                .zero_page_y_set(value: .x)
             }
             0x8e => {
                 // Absolute
                 .clock += 4
                 .pc += 3
-
-                let address = .system.read_word(address: arg_address)
-                .system.write_byte(address, value: .x)
+                .absolute_set(value: .x)
             }
             else => {
                 eprintln("unknown opcode")
@@ -1367,25 +1381,21 @@ class CPU {
                 .clock += 3
                 .pc += 2
 
-                let address = .system.read_byte(address: arg_address)
-                .system.write_byte(address: address as! u16, value: .y)
+                .zero_page_set(value: .y)
             }
             0x94 => {
                 // Zero page, X
                 .clock += 4
                 .pc += 2
 
-                let address = .system.read_byte(address: arg_address)
-                // We wrap around the zero page
-                .system.write_byte(address: unchecked_add<u8>(address, .x) as! u16, value: .y)
+                .zero_page_x_set(value: .y)
             }
             0x8c => {
                 // Absolute
                 .clock += 4
                 .pc += 3
 
-                let address = .system.read_word(address: arg_address)
-                .system.write_byte(address, value: .y)
+                .absolute_set(value: .y)
             }
             else => {
                 eprintln("unknown opcode")
@@ -1715,17 +1725,13 @@ class CPU {
                 .clock += 3
                 .pc += 2
 
-                let address = .system.read_byte(address: arg_address)
-                let value = .system.read_byte(address: address as! u16)
-                yield value
+                yield .zero_page()
             }
             0x2c => {
                 .clock += 4
                 .pc += 3
 
-                let address = .system.read_word(address: arg_address)
-                let value = .system.read_byte(address: address)
-                yield value
+                yield .absolute()
             }
             else => {
                 eprintln("unknown opcode")

--- a/src/cpu.jakt
+++ b/src/cpu.jakt
@@ -330,7 +330,7 @@ class CPU {
         mut address = .system.read_word(address: arg_address)
         let page = address >> 8
 
-        address += .y as! u16
+        address = unchecked_add<u16>(.y as! u16, address)
         let new_page = address >> 8
 
         // Example of crossing pages:
@@ -1270,7 +1270,7 @@ class CPU {
 
                 let address = .system.read_byte(address: arg_address)
                 // TODO: does this wrap around the zero page?
-                .system.write_byte(address: (address + .x) as! u16, value: .a)
+                .system.write_byte(address: unchecked_add<u8>(address, .x) as! u16, value: .a)
             }
             0x8d => {
                 // Absolute
@@ -1286,7 +1286,7 @@ class CPU {
                 .pc += 3
 
                 let address = .system.read_word(address: arg_address)
-                .system.write_byte(address: address + .x as! u16, value: .a)
+                .system.write_byte(address: unchecked_add<u16>(address, .x as! u16), value: .a)
             }
             0x99 => {
                 // Absolute, Y
@@ -1294,7 +1294,7 @@ class CPU {
                 .pc += 3
 
                 let address = .system.read_word(address: arg_address)
-                .system.write_byte(address: address + .y as! u16, value: .a)
+                .system.write_byte(address: unchecked_add<u16>(address, .y as! u16), value: .a)
             }
             0x81 => {
                 // Indirect, X
@@ -1342,7 +1342,7 @@ class CPU {
 
                 let address = .system.read_byte(address: arg_address)
                 // TODO: does this wrap around the zero page?
-                .system.write_byte(address: (address + .y) as! u16, value: .x)
+                .system.write_byte(address: unchecked_add<u8>(address, .y) as! u16, value: .x)
             }
             0x8e => {
                 // Absolute
@@ -1376,8 +1376,8 @@ class CPU {
                 .pc += 2
 
                 let address = .system.read_byte(address: arg_address)
-                // TODO: does this wrap around the zero page?
-                .system.write_byte(address: (address + .x) as! u16, value: .y)
+                // We wrap around the zero page
+                .system.write_byte(address: unchecked_add<u8>(address, .x) as! u16, value: .y)
             }
             0x8c => {
                 // Absolute

--- a/src/cpu.jakt
+++ b/src/cpu.jakt
@@ -271,8 +271,11 @@ class CPU {
 
         let pre_index = .system.read_word(address)
         let page = pre_index >> 8
-
-        let new_address = pre_index + .y as! u16
+        
+        
+        
+        let new_address: u16 = ((pre_index as! u32 + .y as! u32) && 0xffff)
+       
 
         let new_page = new_address >> 8
 


### PR DESCRIPTION
This PR includes several edits:
 - ~~There was a typo in the big match{} in run_opcode~~ This was already fixed in the `wip` branch
 - #5 increased the PC offset in JSR by 1 (to pc + 3). While this fixed the symptoms of RTS returning to an operand rather than an opcode, the error was in RTS not incrementing the pc by 1 after pulling it from the stack. Fixed now.
 - Stack access was all over the code and warranted some helpers. Added them. Also removed CPU::pull_pc() as it degenerated to `.pc = pull_word()` and it was used only in RTS and RTI, with RTS needing to increment the PC anyways.
 - BRK was pushing the current PC on the stack, not PC + 2. This would have resulted in a BRK loop, since RTI returns to the pushed PC. 
 - The addressing modes (and/or read_memory helpers) lack wrapping support, which should be easy to implement:
    - [x] zero page, zero page x, zero page y
    - [x] indirect zero page x
    - [x] indirect zero page y
    - [x] absolute 
    - [x] absolute x, absolute y
- JMP is a fun one when the address for indirection starts on the last byte of the page, as it does not continue the read on the next page, but wraps around on the current page
- Added missing addressing mode helpers, and used them in places not previously used.