### PR TITLE
Correct Indirect.X for STA to pass all tests in nestest.nes

### DIFF
--- a/src/cpu.jakt
+++ b/src/cpu.jakt
@@ -1304,7 +1304,8 @@ class CPU {
                 .pc += 2
 
                 let address = unchecked_add<u8>(.system.read_byte(address: arg_address), .x) as! u16
-                .system.write_byte(address, value: .a)
+                let new_address = .system.read_word_wrapped(address)
+                .system.write_byte(address: new_address, value: .a)
             }
             0x91 => {
                 // Indirect, Y


### PR DESCRIPTION
A small correction in the Indirect.X addressing mode for the STA opcode. With this change (wrapping the target address correctly in the zero page) all tests in the nestest.nes rom.