### PR TITLE
System - Fixed crash loading carts

### DIFF
--- a/src/system.jakt
+++ b/src/system.jakt
@@ -22,8 +22,15 @@ class System {
             return SystemLoadStatus::Error("not a valid ROM file")
         }
 
-        let vram_page_0000 = cart.chr_rom_pages[0]
-        let vram_page_1000 = cart.chr_rom_pages.last()!
+        mut vram_page_0000: [u8] = [0xFF; 0x1000]
+        mut vram_page_1000: [u8] = [0xFF; 0x1000]
+
+        
+        // Wrap in if in case cart uses CHR-RAM
+        if (cart.chr_rom > 0) {
+            vram_page_0000 = cart.chr_rom_pages[0]
+            vram_page_1000 = cart.chr_rom_pages.last()!
+        }
 
         return SystemLoadStatus::Success(
             System(scratch_ram: [0u8; 0x800] 


### PR DESCRIPTION
If a cart did not have a CHR-ROM, the emulator would crash. Fixing this has at the very least allowed many more of the pre-existing test ROMs to start rather than just crashing.