### PR TITLE
Main/SDL - Add troubleshooting keybinds/functions

### DIFF
--- a/src/main.jakt
+++ b/src/main.jakt
@@ -29,6 +29,8 @@ function main(args: [String]) {
             mut clock_pause: bool = false
             mut one_frame: bool = false
             mut slow_mode: bool = false
+            eprintln("Debugging keys\n--------------")
+            eprintln("D - hold to dump current CPU info\nH - toggle CPU halt\nJ - When halted, run single clock\nL - toggle slow mode")
 
             loop {
                 mut event = sdl.poll_event()
@@ -102,12 +104,17 @@ function main(args: [String]) {
                                 }
                                 H => {
                                     clock_pause = not clock_pause
+                                    eprintln("Clock pause: {}", clock_pause)
                                 }
                                 J => {
-                                    one_frame = true
+                                    if clock_pause {
+                                        one_frame = true
+                                        eprintln("Executing single clock")
+                                    }
                                 }
                                 L => {
                                     slow_mode = not slow_mode
+                                    eprintln("Slow clock mode: {}", slow_mode)
                                 }
                             }
                         }

--- a/src/main.jakt
+++ b/src/main.jakt
@@ -25,101 +25,104 @@ function main(args: [String]) {
             mut cpu = CPU::init(system)
             mut debugger = Debugger::init(cpu)
             mut joypad = system.joypad
-	        mut ppu = system.ppu
+            mut ppu = system.ppu
+            mut clock_pause: bool = false
+            mut one_frame: bool = false
+            mut slow_mode: bool = false
+
             loop {
-                let in_vblank_before = system.ppu.in_vblank
-
-                let cpu_clocks_before = cpu.clock
-                cpu.run_opcode()
-                let cpu_clocks_after = cpu.clock
-
-                if system.debug {
-                    debugger.dump_cpu_state()
-                }
-
-//                mut ppu = system.ppu
-                ppu.tick(cycles: (cpu_clocks_after - cpu_clocks_before) * 3)
-                let in_vblank_after = system.ppu.in_vblank
-
-                if not in_vblank_before and in_vblank_after {
-                    // We're just now in the vblank
-                    draw_frame(sdl, buffer: ppu.video_buffer)
-                    mut event = sdl.poll_event()
-                    if event.has_value() {
-                        match event! {
-                            Quit => {
-                                break
-                            }
-                            KeyDown(key) => {
-                                match key {
-                                    Up => {
-                                        joypad.press_up()
-                                    }
-                                    Down => {
-                                        joypad.press_down()
-                                    }
-                                    Left => {
-                                        joypad.press_left()
-                                    }
-                                    Right => {
-                                        joypad.press_right()
-                                    }
-                                    Return => {
-                                        joypad.press_start()
-                                    }
-                                    Tab => {
-                                        joypad.press_select()
-                                    }
-                                    Z => {
-                                        joypad.press_a()
-                                    }
-                                    X => {
-                                        joypad.press_b()
-                                    }
-                                    D => {
-                                        system.debug_enable()
-                                    }
+                mut event = sdl.poll_event()
+                if event.has_value() {
+                    match event! {
+                        Quit => {
+                            break
+                        }
+                        KeyDown(key) => {
+                            match key {
+                                Up => {
+                                    joypad.press_up()
                                 }
+                                Down => {
+                                    joypad.press_down()
+                                }
+                                Left => {
+                                    joypad.press_left()
+                                }
+                                Right => {
+                                    joypad.press_right()
+                                }
+                                Return => {
+                                    joypad.press_start()
+                                }
+                                Tab => {
+                                    joypad.press_select()
+                                }
+                                Z => {
+                                    joypad.press_a()
+                                }
+                                X => {
+                                    joypad.press_b()
+                                }
+                                D => {
+                                    system.debug_enable()
+                                }
+                                H => {}
+                                J => {}
+                                L => {}
                             }
-                            KeyUp(key) => {
-                                match key {
-                                    Up => {
-                                        joypad.release_up()
-                                    }
-                                    Down => {
-                                        joypad.release_down()
-                                    }
-                                    Left => {
-                                        joypad.release_left()
-                                    }
-                                    Right => {
-                                        joypad.release_right()
-                                    }
-                                    Return => {
-                                        joypad.release_start()
-                                    }
-                                    Tab => {
-                                        joypad.release_select()
-                                    }
-                                    Z => {
-                                        joypad.release_a()
-                                    }
-                                    X => {
-                                        joypad.release_b()
-                                    }
-                                    D => {
-                                        system.debug_disable()
-                                    }
+                        }
+                        KeyUp(key) => {
+                            match key {
+                                Up => {
+                                    joypad.release_up()
+                                }
+                                Down => {
+                                    joypad.release_down()
+                                }
+                                Left => {
+                                    joypad.release_left()
+                                }
+                                Right => {
+                                    joypad.release_right()
+                                }
+                                Return => {
+                                    joypad.release_start()
+                                }
+                                Tab => {
+                                    joypad.release_select()
+                                }
+                                Z => {
+                                    joypad.release_a()
+                                }
+                                X => {
+                                    joypad.release_b()
+                                }
+                                D => {
+                                    system.debug_disable()
+                                }
+                                H => {
+                                    clock_pause = not clock_pause
+                                }
+                                J => {
+                                    one_frame = true
+                                }
+                                L => {
+                                    slow_mode = not slow_mode
                                 }
                             }
                         }
                     }
                 }
-            
-                if not in_vblank_before and in_vblank_after and ppu.nmi_on_vblank {
-                    // println("==NMI==")
-                    cpu.nmi()
+                if one_frame {
+                    nesclock(system, cpu, debugger, sdl)
+                    one_frame = false
                 }
+                if slow_mode {
+                    nesclock(system, cpu, debugger, sdl)
+                    sdl.delay(5u32)
+                }
+                if not clock_pause and not slow_mode {nesclock(system, cpu, debugger, sdl) }
+
             }
         }
         Error(msg) => {
@@ -131,4 +134,30 @@ function main(args: [String]) {
 
     sdl.quit()
     return 0
+}
+
+function nesclock (mut system: System, mut cpu: CPU, mut debugger: Debugger, mut sdl: SDL) throws {
+    let in_vblank_before = system.ppu.in_vblank
+
+    let cpu_clocks_before = cpu.clock
+    cpu.run_opcode()
+    let cpu_clocks_after = cpu.clock
+
+    if system.debug {
+        debugger.dump_cpu_state()
+    }
+
+    system.ppu.tick(cycles: (cpu_clocks_after - cpu_clocks_before) * 3)
+    let in_vblank_after = system.ppu.in_vblank
+
+    if not in_vblank_before and in_vblank_after {
+        // We're just now in the vblank
+        draw_frame(sdl, buffer: system.ppu.video_buffer)
+
+    }
+
+    if not in_vblank_before and in_vblank_after and system.ppu.nmi_on_vblank {
+        // println("==NMI==")
+        cpu.nmi()
+    }
 }

--- a/src/sdl.jakt
+++ b/src/sdl.jakt
@@ -17,6 +17,7 @@ import extern c "SDL.h" {
     extern function SDL_DestroyRenderer(renderer: raw SDL_Renderer) -> void
     extern function SDL_DestroyWindow(window: raw SDL_Window) -> void
     extern function SDL_Quit() -> void
+    extern function SDL_Delay(ms: u32) -> void
 }
 
 enum Key {
@@ -29,6 +30,9 @@ enum Key {
     X
     Tab
     D
+    H
+    J
+    L
 }
 
 enum SDLEvent {
@@ -134,6 +138,15 @@ class SDL {
                     } else if (event.key.keysym.scancode == SDL_SCANCODE_D) {
                         const Optional<SDLEvent> event = typename SDLEvent::KeyDown(typename Key::D());
                         return event;
+                    } else if (event.key.keysym.scancode == SDL_SCANCODE_H) {
+                        const Optional<SDLEvent> event = typename SDLEvent::KeyDown(typename Key::H());
+                        return event;
+                    } else if (event.key.keysym.scancode == SDL_SCANCODE_J) {
+                        const Optional<SDLEvent> event = typename SDLEvent::KeyDown(typename Key::J());
+                        return event;
+                    } else if (event.key.keysym.scancode == SDL_SCANCODE_L) {
+                        const Optional<SDLEvent> event = typename SDLEvent::KeyDown(typename Key::L());
+                        return event;
                     }
                 } else if (has_event && event.type == SDL_KEYUP) {
                     if (event.key.keysym.scancode == SDL_SCANCODE_UP) {
@@ -163,6 +176,15 @@ class SDL {
                     } else if (event.key.keysym.scancode == SDL_SCANCODE_D) {
                         const Optional<SDLEvent> event = typename SDLEvent::KeyUp(typename Key::D());
                         return event;
+                    } else if (event.key.keysym.scancode == SDL_SCANCODE_H) {
+                        const Optional<SDLEvent> event = typename SDLEvent::KeyUp(typename Key::H());
+                        return event;
+                    } else if (event.key.keysym.scancode == SDL_SCANCODE_J) {
+                        const Optional<SDLEvent> event = typename SDLEvent::KeyUp(typename Key::J());
+                        return event;
+                    } else if (event.key.keysym.scancode == SDL_SCANCODE_L) {
+                        const Optional<SDLEvent> event = typename SDLEvent::KeyUp(typename Key::L());
+                        return event;
                     }
                 }"
             }
@@ -176,6 +198,12 @@ class SDL {
             SDL_DestroyRenderer(renderer: .renderer)
             SDL_DestroyWindow(window: .window)
             SDL_Quit()
+        }
+    }
+
+    public function delay(this, anon ms:u32) {
+        unsafe {
+            SDL_Delay(ms)
         }
     }
 }


### PR DESCRIPTION
The emulator logic is now separated from the loop in main. This allows for keybinds to perform troubleshooting functions. H toggles a complete pause, when paused J will do a single frame. L toggles an arbitrary delay to be better able to manually monitor memory or the debug output.