### PR TITLE
PPU - fix runtime overflow in get_sprite_pixel

### DIFF
--- a/src/ppu.jakt
+++ b/src/ppu.jakt
@@ -12,7 +12,16 @@ class Sprite {
     public sprite_zero: bool
 
     public function get_sprite_pixel(this, x: u8) -> (bool, u8){
-        guard x >= .sprite_x and x < (.sprite_x + 8) else {
+
+
+        //FIXME: surely there is a more elegant way to handle overflows
+        mut spritemax: u8 = 0
+        if .sprite_x > 247u8 {
+            spritemax = 255u8
+        } else {
+            spritemax = .sprite_x + 8
+        }
+        guard x >= .sprite_x and x < (spritemax) else {
             return(false, 0u8)
         }
 

--- a/src/ppu.jakt
+++ b/src/ppu.jakt
@@ -13,24 +13,21 @@ class Sprite {
 
     public function get_sprite_pixel(this, x: u8) -> (bool, u8){
 
-
-        //FIXME: surely there is a more elegant way to handle overflows
-        mut spritemax: u8 = 0
-        if .sprite_x > 247u8 {
-            spritemax = 255u8
-        } else {
-            spritemax = .sprite_x + 8
-        }
-        guard x >= .sprite_x and x < (spritemax) else {
+        //TODO (?): How did the hardware handle this with 8 bits?
+        guard x >= .sprite_x and (x as! u16) < ((.sprite_x as! u16) + 8u16) else {
             return(false, 0u8)
         }
 
-        let shift_amount = match .hflip {
-            true => x - .sprite_x
-            else => 7 - (x - .sprite_x)
+        mut shift_amount = match .hflip {
+            true => (x - .sprite_x) as! i16
+            else => 7 - (x as! i16 - .sprite_x as! i16)
         }
 
-        let entry = .mask[shift_amount]
+        if (shift_amount < 0) {
+            shift_amount = 0
+        }
+
+        let entry = .mask[shift_amount as! u8]
 
         return (true, entry)
     }


### PR DESCRIPTION
Per the fixme, there's got to be a better way to handle this that I just don't know about.