### PR TITLE
Cart - More fixes for chrram carts

### DIFF
--- a/src/cart.jakt
+++ b/src/cart.jakt
@@ -51,6 +51,9 @@ function load_cart(filename: String) throws -> CartLoadStatus {
     mut prg_rom_pages: [[u8]] = []
     let prg_rom_page_size: usize = 16 * 1024
     mut current_start: usize = 16
+    if (chr_rom == 0) {
+        current_start = 0x2010
+    }
 
     for page in 0..prg_rom {
         mut current_page: [u8] = []


### PR DESCRIPTION
This change actually allows chrram roms to load. The previous fix only stopped them from crashing the program. When byte 5 in the rom is 0, indicating the cart uses chrram, the current start is pushed to 0x2010 where data is expected to begin.