### PR TITLE
fix some of the frame timing logic

### DIFF
--- a/src/ppu.jakt
+++ b/src/ppu.jakt
@@ -429,17 +429,19 @@ class PPU {
     function render_pixel(mut this) throws {
         // BACKGROUND
         //println("Hpx: {}, Vpx: {}", horizontal_pixel, vertical_pixel)
-        if .horizontal_pixel == 256 and .rendering_enabled {
+        let visible_row = (.vertical_pixel < 240) or (.vertical_pixel == 261)
+
+        if .horizontal_pixel == 256 and visible_row and .rendering_enabled {
             .y_increment()
         }
 
-        if .horizontal_pixel == 257 and .rendering_enabled {
+        if .horizontal_pixel == 257 and visible_row and .rendering_enabled {
             let abcdef = .t & 0x41f
             .v = .v & 0xbe0
             .v = .v | abcdef
         }
 
-        if (.horizontal_pixel >= 280) and (.horizontal_pixel <= 304) and (.vertical_pixel == 262) and .rendering_enabled {
+        if (.horizontal_pixel >= 280) and (.horizontal_pixel <= 304) and (.vertical_pixel == 261) and .rendering_enabled {
             // GHIA.BC DEF.....
             let ghiabcdef = .t & 0x7be0
             .v = .v & 0x41f


### PR DESCRIPTION
This follows the frame timings in https://www.nesdev.org/w/images/default/d/d1/Ntsc_timing.png a little bit more closely.

Namely, we don't do the increments to y during vblank, only during the visible frame and the pre-render scanline. Same is true for the partial copy of t to v in the PPU.

This fixes a lot of games back to their original level of support, including nestest now working correctly again.