### PR TITLE
Add DMA timing to clock counts

### DIFF
--- a/src/ppu.jakt
+++ b/src/ppu.jakt
@@ -63,10 +63,11 @@ class PPU {
     sprite_overflow: bool
     public debug: bool
     rendering_enabled: bool
-    even_frame_flag: bool
+    public even_frame_flag: bool
     horizontal_pixel: u64
     vertical_pixel: u64
     mirroring: Mirroring
+    dma_ticks: u64
 
     // Internal PPU registers (from https://www.nesdev.org/wiki/PPU_scrolling)
     v: u16
@@ -108,6 +109,7 @@ class PPU {
             horizontal_pixel: 0
             vertical_pixel: 0
             mirroring
+            dma_ticks: 0
 
             // internal PPU registers
             v: 0
@@ -182,6 +184,14 @@ class PPU {
                     rgb(0    0    0)
                 ]   
         )
+    }
+
+    public function dma_tick(mut this) throws {
+        if .even_frame_flag {
+            .tick(cycles: 513 * 3u64)
+        } else {
+            .tick(cycles: 514 * 3u64)
+        }
     }
 
     public function tick(mut this, cycles: u64) throws {
@@ -806,7 +816,7 @@ class PPU {
             0x2000 => .ppu_ctrl(value)
             0x2001 => .ppu_mask(value)
             0x2003 => .oam_addr_write(value) //From NESDEV wiki - most games write $00 here and use OAMDMA
-            //0x2004 => .oam_data(value) // TODO
+            // 0x2004 => .oam_data_write(value)
             0x2005 => .ppu_scroll(value) // Write twice
             0x2006 => .ppu_addr(value) // Write twice
             0x2007 => .ppu_data_write(value)
@@ -821,11 +831,12 @@ class PPU {
         .oam_addr = value
     }
 
+
     public function read_ppu_addr(mut this, address: u16) -> u8 {
         let mirrored_address = (address % 0x8) + 0x2000
         return match mirrored_address {
             0x2002 => .ppu_status()
-            //0x2004 => .oam_data() // TODO?
+            // 0x2004 => .oam_data_read()
             0x2007 => .ppu_data_read()
             else => {
                 eprintln("Unimplemented read from: {:0>4x}", mirrored_address)

--- a/src/system.jakt
+++ b/src/system.jakt
@@ -24,7 +24,6 @@ class System {
 
         mut vram_page_0000: [u8] = [0xFF; 0x1000]
         mut vram_page_1000: [u8] = [0xFF; 0x1000]
-
         
         // Wrap in if in case cart uses CHR-RAM
         if (cart.chr_rom > 0) {
@@ -107,6 +106,9 @@ class System {
             .ppu.write_ppu_addr(address, value)
         } else if address == 0x4014 {
             .oam_dma(value)
+            try {
+                .ppu.dma_tick()
+            } catch {}
         } else if address == 0x4016 {
             if (value & 0x1) == 0x1 {
                 .joypad.poll_joypad()


### PR DESCRIPTION
This gets the scanline test *much* closer to being correct:

<img width="503" alt="image" src="https://user-images.githubusercontent.com/547158/195245289-1f9c3b5d-52cd-4857-a04a-96dafa4a8a55.png">
