### PR TITLE
PPU - only find_sprites once

### DIFF
--- a/src/ppu.jakt
+++ b/src/ppu.jakt
@@ -213,7 +213,8 @@ class PPU {
             .clock += 1
 
             // 257-320 = sprite tile loading interval
-            if (.horizontal_pixel >= 257) and (.horizontal_pixel <= 320) and ((.vertical_pixel >= 0) and (.vertical_pixel <= 239)) {
+            if (.horizontal_pixel == 320) and ((.vertical_pixel >= 0) and (.vertical_pixel <= 239)) {
+
                 // .oam_addr = 0x00
                 .second_oam = .find_sprites(scanline: (.vertical_pixel + 1) as! u8)
             }


### PR DESCRIPTION
On real hardware, filling the second OAM may legitimately require multiple cycles to complete. In the emulator, it seems like running this at any time other than horizontal_pixel == 320 may be unnecessary.

This change takes SMB from "fast" to "unplayable".