### PR TITLE
Better delay + better PAL detection

### DIFF
--- a/src/apu.jakt
+++ b/src/apu.jakt
@@ -56,7 +56,7 @@ class APU {
         .pulse1.render()
         .pulse2.render()
         .triangle.render()
-        .noise.render()
+        // .noise.render()
 
         // FIXME: rendering needs to use the PPU mixer
         while i < 44100 / 60 {

--- a/src/cart.jakt
+++ b/src/cart.jakt
@@ -23,6 +23,7 @@ class Cart {
     public chr_rom_pages: [[u8]]
 
     public fn info(this) {
+        println("region: {}", .region)
         println("prg_rom: {}", .prg_rom)
         println("chr_rom: {}", .chr_rom)
         println("mirroring: {}", .mirroring)
@@ -72,12 +73,21 @@ fn load_cart(filename: String) throws -> CartLoadStatus {
         abort()
     }
 
-    let region = match buffer[12] & 0x3 {
+    mut region = match buffer[10] & 0x3 {
         0 => Region::NTSC
         1 => Region::PAL
         2 => Region::Multi
         3 => Region::Dendy
         else => Region::NTSC
+    }
+
+    if filename.contains("(E)") {
+        region = Region::PAL
+    }
+
+    guard region is NTSC else {
+        eprintln("Region {} is not currently supported", region)
+        abort()
     }
 
     mut prg_rom_pages: [[u8]] = []

--- a/src/main.jakt
+++ b/src/main.jakt
@@ -243,32 +243,13 @@ fn clocktick(mut system: System, mut cpu: CPU, mut debugger: Debugger, mut sdl: 
         // println("{}", system.apu.buffer)
         sdl.queue_audio(data: system.apu.buffer)
 
-        // Let's try to create one frame of audio
-        // Uncomment for test sine wave
-        // mut i = 0
-        // let frame_size = (44100 / 60)
-        // while i < frame_size {
-        //     system.audio_clock += 0.010
-        //     unsafe {
-        //         cpp {
-        //             "system->audio_buffer[i] = sin(system->audio_clock * 4.0) * 5000;"
-        //         }
-        //     }
-        //     ++i
-        // }
-        // sdl.queue_audio(data: system.audio_buffer)
-
         // Finally, let's burn some time so that we're at 60fps
-
-        let delta = sdl.delta_time() as! u32
-
-        let ms_per_frame = 1000u32 / 60u32
+        let delta = sdl.delta_time()
+        let ms_per_frame = 1000u64 / 60u64
 
         if delta < ms_per_frame {
-            // println("{}", ms_per_frame - delta)
-
-            // Why do I have to do * 2 to get close?!
-            sdl.delay(ms: (ms_per_frame - delta) * 2)
+            sdl.delay(ms: (ms_per_frame - delta) as! u32)
+            sdl.delta_time()
         }
     }
 


### PR DESCRIPTION
This fixes the delay logic to more correctly estimate the length the frame took to render. Previously, the ticks were calculated once per frame, but we delayed after the ticks were calculated. This meant the delay itself was getting added to the frame timing. This threw off every other frame, and caused our math to drift.

We still may have math issues, but hopefully we can sort those out separately. At least now, we're properly timing the current frame.